### PR TITLE
About `csc`, `sec`, `cot`

### DIFF
--- a/src/Symbolics/Approximation.fs
+++ b/src/Symbolics/Approximation.fs
@@ -88,7 +88,17 @@ module Approximation =
         | Real a -> Real (Math.Atan a)
         | Complex a -> Complex (C.Atan a)
 
-    let apply (f:Function) a =
+    let cot = function
+        | Real a -> Real (Trig.Cot a)
+        | Complex a -> Complex (Complex.cot a)
+    let sec = function
+        | Real a -> Real (Trig.Sec a)
+        | Complex a -> Complex (Complex.sec a)
+    let csc = function
+        | Real a -> Real (Trig.Csc a)
+        | Complex a -> Complex (Complex.csc a)
+
+    let apply f a =
         match f with
         | Abs -> abs a
         | Ln -> ln a
@@ -102,6 +112,9 @@ module Approximation =
         | Asin -> asin a
         | Acos -> acos a
         | Atan -> atan a
+        | Cot -> cot a
+        | Sec -> sec a
+        | Csc -> csc a
 
     let isZero = function
         | Real x when x = 0.0 -> true

--- a/src/Symbolics/Calculus.fs
+++ b/src/Symbolics/Calculus.fs
@@ -32,6 +32,9 @@ module Calculus =
         | Function (Asin, x) -> (1Q/sqrt(1Q+pow x 2Q)) * (differentiate symbol x)
         | Function (Acos, x) -> (-1Q/sqrt(1Q+pow x 2Q)) * (differentiate symbol x)
         | Function (Atan, x) -> (1Q/1Q+pow x 2Q) * (differentiate symbol x)
+        | Function (Cot, x) -> (-1Q/(sin(x) * sin(x))) * (differentiate symbol x)
+        | Function (Csc, x) -> (-cot(x) * csc(x)) * (differentiate symbol x)
+        | Function (Sec, x) -> (tan(x) * sec(x)) * (differentiate symbol x)
         | FunctionN (f, xs) -> failwith "not supported"
         | Function (Abs, _) -> failwith "not supported"
         | Product [] -> failwith "invalid expression"

--- a/src/Symbolics/Convert/Infix.fs
+++ b/src/Symbolics/Convert/Infix.fs
@@ -152,6 +152,7 @@ module private InfixFormatter =
         | Acos -> "acos" | Asin -> "asin" | Atan -> "atan"
         | Sinh -> "sinh" | Cosh -> "cosh" | Tanh -> "tanh"
         | Sin -> "sin" | Cos -> "cos" | Tan -> "tan"
+        | Cot -> "cot" | Sec -> "sec" | Csc -> "csc"
 
     // priority: 1=additive 2=product 3=power
 

--- a/src/Symbolics/Convert/LaTeX.fs
+++ b/src/Symbolics/Convert/LaTeX.fs
@@ -38,6 +38,7 @@ module private LaTeXFormatter =
         | Sin -> "\\sin" | Cos -> "\\cos" | Tan -> "\\tan"
         | Sinh -> "\\sinh" | Cosh -> "\\cosh" | Tanh -> "\\tanh"
         | Asin -> "\\arcsin" | Acos -> "\\arccos" | Atan -> "\\arctan"
+        | Cot -> "\\cot" | Sec -> "\\sec" | Csc -> "\\csc"
 
     let private nextNumber = function
          | Power (Number _, _)

--- a/src/Symbolics/Evaluate.fs
+++ b/src/Symbolics/Evaluate.fs
@@ -156,6 +156,12 @@ module Evaluate =
         | Acos, Complex x -> Complex (Complex.Acos(x))
         | Atan, Real x -> Real (Math.Atan(x))
         | Atan, Complex x -> Complex (Complex.Atan(x))
+        | Cot, Real x -> Real (Trig.Cot x)
+        | Cot, Complex x -> Complex(Trig.Cot x)
+        | Sec, Real x -> Real (Trig.Sec x)
+        | Sec, Complex x -> Complex(Trig.Sec x)
+        | Csc, Real x -> Real (Trig.Sec x)
+        | Csc, Complex x -> Complex(Trig.Sec x)
         | _ -> failwith "not supported"
 
     let fapplyN f xs = failwith "not supported yet"

--- a/src/Symbolics/Expression.fs
+++ b/src/Symbolics/Expression.fs
@@ -377,9 +377,10 @@ module Operators =
         | Number n when n.IsNegative -> negate (Function (Tan, Number -n))
         | Product ((Number n)::ax) when n.IsNegative -> negate (Function (Tan, multiply (Number -n) (Product ax)))
         | x -> Function (Tan, x)
-    let cot x = tan x |> invert
-    let sec x = cos x |> invert
-    let csc x = sin x |> invert
+
+    let cot x = Function (Cot, x)
+    let sec x = Function (Sec, x)
+    let csc x = Function (Csc, x)
     let cosh x = Function (Cosh, x)
     let sinh x = Function (Sinh, x)
     let tanh x = Function (Tanh, x)
@@ -401,6 +402,9 @@ module Operators =
         | Asin -> arcsin x
         | Acos -> arccos x
         | Atan -> arctan x
+        | Cot -> cot x
+        | Sec -> sec x
+        | Csc -> csc x
 
     let applyN (f: Function) (xs: Expression list) = failwith "not supported yet"
 
@@ -451,6 +455,9 @@ type Expression with
     static member ArcSin (x) = Operators.arcsin x
     static member ArcCos (x) = Operators.arccos x
     static member ArcTan (x) = Operators.arctan x
+    static member Cot (x) = Operators.cot x
+    static member Csc (x) = Operators.csc x
+    static member Sec (x) = Operators.sec x
 
     static member Apply (f, x) = Operators.apply f x
     static member ApplyN (f, xs) = Operators.applyN f xs
@@ -482,7 +489,6 @@ type Expression with
     static member op_Implicit (x:BigInteger) = Operators.fromInteger(x)
     static member op_Implicit (x:BigRational) = Operators.fromRational(x)
     static member op_Implicit (x:float) = Operators.real x
-    static member op_Implicit (name:string) = Operators.symbol(name)
 
 
 [<RequireQualifiedAccess>]

--- a/src/Symbolics/Symbols.fs
+++ b/src/Symbolics/Symbols.fs
@@ -6,6 +6,7 @@ type Function =
     | Abs
     | Ln | Exp
     | Sin | Cos | Tan
+    | Cot | Sec | Csc 
     | Cosh | Sinh | Tanh
     | Asin | Acos | Atan
 

--- a/src/SymbolicsUnitTests/Tests.fs
+++ b/src/SymbolicsUnitTests/Tests.fs
@@ -230,8 +230,6 @@ let ``Expressions are always in auto-simplified form`` () =
     exp 0Q ==> "1"
 
     sin x ==> "sin(x)"
-    cot x ==> "1/tan(x)"
-    sec x ==> "1/cos(x)"
 
 
 [<Test>]
@@ -313,7 +311,7 @@ let ``Print LaTeX expressions`` () =
     LaTeX.format Expression.MinusOne --> """-1"""
     LaTeX.format Expression.ComplexInfinity --> """\infty"""
     LaTeX.format Expression.Pi --> """\pi"""
-    LaTeX.format (Expression.Real -0.23) --> (-0.23).ToString()
+    LaTeX.format (Expression.Real -0.23) --> string -0.23
     LaTeX.format (a**b) --> """{a}^{b}"""
     LaTeX.format (a**(b+c)) --> """{a}^{\left(b + c\right)}"""
     LaTeX.format ((a+b)**c) --> """{\left(a + b\right)}^{c}"""
@@ -862,3 +860,18 @@ let ``Underscores in names`` () =
     let expr2 = Infix.parseOrUndefined "(TESTING_UNDER_second)*(2)" 
     expr2 ==> "2*TESTING_UNDER_second"
     LaTeX.format expr2 --> """2{TESTING_{UNDER_{second}}}""" 
+
+[<Test>]
+let ``Test for other trigonometric function``() = 
+
+    let exrp = Infix.parseOrUndefined "tan(x)*25*csc(x)"
+    exrp ==> "25*tan(x)*csc(x)"
+   
+    let expr2 = Operators.sec 32Q 
+    expr2 ==> "sec(32)"
+
+    let exrp3 = Expression.Apply(Function.Cot, expr2)
+    exrp3 ==> "cot(sec(32))"
+
+    let expr4 = Infix.parseOrUndefined "25*x*sec(x)"
+    Calculus.differentiate x expr4  ==> "25*sec(x) + 25*x*tan(x)*sec(x)"

--- a/src/SymbolicsUnitTests/Tests.fs
+++ b/src/SymbolicsUnitTests/Tests.fs
@@ -874,4 +874,4 @@ let ``Test for other trigonometric function``() =
     exrp3 ==> "cot(sec(32))"
 
     let expr4 = Infix.parseOrUndefined "25*x*sec(x)"
-    Calculus.differentiate x expr4  ==> "25*sec(x) + 25*x*tan(x)*sec(x)"
+    Calculus.differentiate x expr4  ==> "25*(sec(x) + x*tan(x)*sec(x))"


### PR DESCRIPTION
Added basic support for some additional trigonometric functions (https://github.com/mathnet/mathnet-symbolics/issues/24)
Removed implicit conversion operator (https://github.com/mathnet/mathnet-symbolics/issues/26)

