### PR TITLE
Fix Trigonometric.substitute

### DIFF
--- a/src/Symbolics/Trigonometric.fs
+++ b/src/Symbolics/Trigonometric.fs
@@ -106,6 +106,9 @@ module Trigonometric =
     let rec substitute x =
         match x with
         | Function (Tan, a) -> let a' = substitute a in sin(a')/cos(a')
+        | Function (Cot, a) -> let a' = substitute a in cos(a')/sin(a')
+        | Function (Sec, a) -> let a' = substitute a in one/cos(a')
+        | Function (Csc, a) -> let a' = substitute a in one/sin(a')
         | Sum ax -> sum <| List.map substitute ax
         | Product ax -> product <| List.map substitute ax
         | Power (radix, p) -> (substitute radix) ** (substitute p)

--- a/src/SymbolicsUnitTests/Tests.fs
+++ b/src/SymbolicsUnitTests/Tests.fs
@@ -501,6 +501,11 @@ let ``Algebaric Operators`` () =
 
     Trigonometric.simplify ((cos(x)+sin(x))**4 + (cos(x)-sin(x))**4 + cos(4*x) - 3) ==> "0"
 
+    Trigonometric.substitute (tan(x)) ==> "sin(x)/cos(x)"
+    Trigonometric.substitute (cot(x)) ==> "cos(x)/sin(x)"
+    Trigonometric.substitute (csc(x)) ==> "1/sin(x)"
+    Trigonometric.substitute (sec(x)) ==> "1/cos(x)"
+
     // TODO: expected: 0
     Trigonometric.simplify (sin(x) + sin(y) - 2*sin(x/2+y/2)*cos(x/2-y/2))
         ==> "sin(y) - (1/2)*sin(x - y) - (1/2)*sin((1/2)*x - (1/2)*y - ((1/2)*x - (1/2)*y)) - (1/2)*sin(-(1/2)*x + (1/2)*y - ((1/2)*x - (1/2)*y)) - sin((1/2)*x + (1/2)*y - ((1/2)*x - (1/2)*y))"


### PR DESCRIPTION
Without this patch, Trigonometric.substitute ignores the Cotangent, Secant and Cosecant functions. Now they are handled correctly and are not passed onto subsequent iterations.