### PR TITLE
Multiarg functions

### DIFF
--- a/src/Symbolics/Approximation.fs
+++ b/src/Symbolics/Approximation.fs
@@ -57,10 +57,10 @@ module Approximation =
     let ln = function
         | Real a -> Real (Math.Log a)
         | Complex a -> Complex (C.Log a)
-    let log = function
+    let log10 = function
         | Real a -> Real (Math.Log10 a)
         | Complex a -> Complex (C.Log10 a)
-    let logn b x =
+    let log b x =
         match b, x with
         | Real v, Real w -> Real (Math.Log (v, w))
         | Real v, Complex w -> Complex (Complex.Log (w, v))
@@ -116,7 +116,7 @@ module Approximation =
         match f with
         | Abs -> abs a
         | Ln -> ln a
-        | Log -> log a
+        | Log -> log10 a
         | Exp -> exp a
         | Sin ->sin a
         | Cos -> cos a
@@ -134,7 +134,7 @@ module Approximation =
     let applyN f xs =
         match f, xs with
         | Atan, [x; y] -> atan2 x y
-        | Log, [b; x] -> logn b x
+        | Log, [b; x] -> log b x
         | _ -> failwith "not supported"
 
     let isZero = function

--- a/src/Symbolics/Approximation.fs
+++ b/src/Symbolics/Approximation.fs
@@ -57,6 +57,14 @@ module Approximation =
     let ln = function
         | Real a -> Real (Math.Log a)
         | Complex a -> Complex (C.Log a)
+    let log = function
+        | Real a -> Real (Math.Log10 a)
+        | Complex a -> Complex (C.Log10 a)
+    let logn b x =
+        match b, x with
+        | Real v, Real w -> Real (Math.Log (v, w))
+        | Real v, Complex w -> Complex (Complex.Log (w, v))
+        | _ -> failwith "not supported"
     let exp = function
         | Real a -> Real (Math.Exp a)
         | Complex a -> Complex (C.Exp a)
@@ -87,6 +95,12 @@ module Approximation =
     let atan = function
         | Real a -> Real (Math.Atan a)
         | Complex a -> Complex (C.Atan a)
+    let atan2 x y =
+        match x, y with
+        | Real a, Real b -> Real (Math.Atan2 (a, b))
+        | Complex a, Complex b -> Complex (Complex.Atan (a / b))
+        | Complex a, Real b -> Complex (Complex.Atan (a / (Complex.Create (b, 0.0))))
+        | Real a, Complex b -> Complex (Complex.Atan ((Complex.Create (a, 0.0)) / b))
 
     let cot = function
         | Real a -> Real (Trig.Cot a)
@@ -102,6 +116,7 @@ module Approximation =
         match f with
         | Abs -> abs a
         | Ln -> ln a
+        | Log -> log a
         | Exp -> exp a
         | Sin ->sin a
         | Cos -> cos a
@@ -115,6 +130,12 @@ module Approximation =
         | Cot -> cot a
         | Sec -> sec a
         | Csc -> csc a
+
+    let applyN f xs =
+        match f, xs with
+        | Atan, [x; y] -> atan2 x y
+        | Log, [b; x] -> logn b x
+        | _ -> failwith "not supported"
 
     let isZero = function
         | Real x when x = 0.0 -> true

--- a/src/Symbolics/Calculus.fs
+++ b/src/Symbolics/Calculus.fs
@@ -23,6 +23,7 @@ module Calculus =
             de*ln(r)*p + e*dr*(r**(e-1))
         | Function (Exp, x) as f -> (differentiate symbol x) * f
         | Function (Ln, x) -> (differentiate symbol x) / x
+        | Function (Log, x) -> (differentiate symbol ((ln x) / (ln 10Q)))
         | Function (Sin, x) -> (differentiate symbol x) * cos(x)
         | Function (Cos, x) -> -(differentiate symbol x) * sin(x)
         | Function (Tan, x) -> 2*(differentiate symbol x) / (cos(2*x)+1)
@@ -35,8 +36,10 @@ module Calculus =
         | Function (Cot, x) -> (-1Q/(sin(x) * sin(x))) * (differentiate symbol x)
         | Function (Csc, x) -> (-cot(x) * csc(x)) * (differentiate symbol x)
         | Function (Sec, x) -> (tan(x) * sec(x)) * (differentiate symbol x)
-        | FunctionN (f, xs) -> failwith "not supported"
         | Function (Abs, _) -> failwith "not supported"
+        | FunctionN (Atan, [x; y]) -> differentiate symbol (tan (x / y))
+        | FunctionN (Log, [b; x]) -> differentiate symbol ((ln x) / (ln b))
+        | FunctionN (_) -> failwith "not supported"
         | Product [] -> failwith "invalid expression"
 
     /// Differentiate expression to symbol and substitute symbol with value

--- a/src/Symbolics/Convert/Infix.fs
+++ b/src/Symbolics/Convert/Infix.fs
@@ -128,7 +128,7 @@ module private InfixFormatter =
 
     let functionName = function
         | Abs -> "abs"
-        | Ln -> "ln"
+        | Ln -> "ln" | Log -> "log"
         | Exp -> "exp"
         | Acos -> "acos" | Asin -> "asin" | Atan -> "atan"
         | Sinh -> "sinh" | Cosh -> "cosh" | Tanh -> "tanh"

--- a/src/Symbolics/Convert/LaTeX.fs
+++ b/src/Symbolics/Convert/LaTeX.fs
@@ -191,6 +191,14 @@ module private LaTeXFormatter =
             tex write 0 x
             write "\\right)"
             if priority > 3 then write "\\right)"
+        | FunctionN (Atan, [y; x]) ->
+            if priority > 3 then write "\\left("
+            write "\\operatorname{atan2}\\left({{"
+            tex write 0 y
+            write "}, {"
+            tex write 0 x
+            write "}}\\right)"
+            if priority > 3 then write "\\right)"
         | FunctionN (fn, x::xs) ->
             if priority > 3 then write "\\left("
             write (functionName fn)

--- a/src/Symbolics/Convert/LaTeX.fs
+++ b/src/Symbolics/Convert/LaTeX.fs
@@ -33,7 +33,7 @@ module private LaTeXFormatter =
 
     let functionName = function
         | Abs -> "\\mathrm{abs}"
-        | Ln -> "\\ln"
+        | Ln -> "\\ln" | Log -> "\\log"
         | Exp -> "\\exp"
         | Sin -> "\\sin" | Cos -> "\\cos" | Tan -> "\\tan"
         | Sinh -> "\\sinh" | Cosh -> "\\cosh" | Tanh -> "\\tanh"
@@ -170,12 +170,26 @@ module private LaTeXFormatter =
             write "\\mathrm{e}^"
             tex write 4 x
             if priority > 3 then write "\\right)"
+        | Function (Log, x) ->
+            if priority > 3 then write "\\left("
+            write "\\log_{10}\\left("
+            tex write 0 x
+            write "\\right)"
+            if priority > 3 then write "\\right)"
         | Function (fn, x) ->
             if priority > 3 then write "\\left("
             write (functionName fn)
             write "{"
             tex write 3 x
             write "}"
+            if priority > 3 then write "\\right)"
+        | FunctionN (Log, [basis; x]) ->
+            if priority > 3 then write "\\left("
+            write "\\log_{"
+            tex write 0 basis
+            write "}\\left("
+            tex write 0 x
+            write "\\right)"
             if priority > 3 then write "\\right)"
         | FunctionN (fn, x::xs) ->
             if priority > 3 then write "\\left("

--- a/src/Symbolics/Evaluate.fs
+++ b/src/Symbolics/Evaluate.fs
@@ -136,6 +136,8 @@ module Evaluate =
         | Abs, ComplexMatrix x -> Real (x.L2Norm())
         | Ln, Real x -> Real (Math.Log(x))
         | Ln, Complex x -> Complex (Complex.Log(x))
+        | Log, Real x -> Real (Math.Log10(x))
+        | Log, Complex x -> Complex(Complex.Log10(x))
         | Exp, Real x -> Real (Math.Exp(x))
         | Exp, Complex x -> Complex (Complex.Exp(x))
         | Sin, Real x -> Real (Math.Sin(x))
@@ -164,7 +166,15 @@ module Evaluate =
         | Csc, Complex x -> Complex(Trig.Sec x)
         | _ -> failwith "not supported"
 
-    let fapplyN f xs = failwith "not supported yet"
+    let fapplyN f xs =
+        match f, xs with
+        | Atan, [Real x; Real y] -> Real (Math.Atan2(x, y))
+        | Atan, [Complex x; Real y] -> Complex (Complex.Atan(x / Complex.Create(y, 0.0)))
+        | Atan, [Complex x; Complex y] -> Complex (Complex.Atan(x / y))
+        | Atan, [Real x; Complex y] -> Complex (Complex.Atan(Complex.Create(x, 0.0) / y))
+        | Log, [Real b; Real x] -> Real (Math.Log(x, b))
+        | Log, [Real b; Complex x] -> Complex (Complex.Log(x, b))
+        | _ -> failwith "not supported"
 
     [<CompiledName("Evaluate")>]
     let rec evaluate (symbols:IDictionary<string, FloatingPoint>) = function

--- a/src/Symbolics/Evaluate.fs
+++ b/src/Symbolics/Evaluate.fs
@@ -174,6 +174,8 @@ module Evaluate =
         | Atan, [Real x; Complex y] -> Complex (Complex.Atan(Complex.Create(x, 0.0) / y))
         | Log, [Real b; Real x] -> Real (Math.Log(x, b))
         | Log, [Real b; Complex x] -> Complex (Complex.Log(x, b))
+        | Log, [Complex b; Complex x] -> Complex(Complex.Log(x) / Complex.Log(b))
+        | Log, [Complex b; Real x] -> Complex(Complex.Log(Complex.Create(x, 0.0)) / Complex.Log(b))
         | _ -> failwith "not supported"
 
     [<CompiledName("Evaluate")>]

--- a/src/Symbolics/Exponential.fs
+++ b/src/Symbolics/Exponential.fs
@@ -23,11 +23,11 @@ module Exponential =
         let rec lognRules basis = function
             | Product ax -> sum <| List.map (lognRules basis) ax
             | Power (r, p) -> p*lognRules basis r |> Algebraic.expand
-            | x -> logn basis x
+            | x -> log basis x
         match Structure.map expand x with
         | Function (Exp, a) -> expRules (Algebraic.expand a)
         | Function (Ln, a) -> lnRules ln (Algebraic.expand a)
-        | Function (Log, a) -> lnRules log (Algebraic.expand a)
+        | Function (Log, a) -> lnRules log10 (Algebraic.expand a)
         | FunctionN (Log, [basis;a]) -> lognRules basis (Algebraic.expand a)
         | a -> a
 

--- a/src/Symbolics/Exponential.fs
+++ b/src/Symbolics/Exponential.fs
@@ -16,13 +16,19 @@ module Exponential =
             | Sum ax -> product <| List.map expRules ax
             | Product ((Integer _ as n)::ax) -> (expRules (product ax))**n
             | x -> exp x
-        let rec lnRules = function
-            | Product ax -> sum <| List.map lnRules ax
-            | Power (r, p) -> p*lnRules r |> Algebraic.expand
-            | x -> ln x
+        let rec lnRules f = function
+            | Product ax -> sum <| List.map (lnRules f) ax
+            | Power (r, p) -> p*lnRules f r |> Algebraic.expand
+            | x -> f x
+        let rec lognRules basis = function
+            | Product ax -> sum <| List.map (lognRules basis) ax
+            | Power (r, p) -> p*lognRules basis r |> Algebraic.expand
+            | x -> logn basis x
         match Structure.map expand x with
         | Function (Exp, a) -> expRules (Algebraic.expand a)
-        | Function (Ln, a) -> lnRules (Algebraic.expand a)
+        | Function (Ln, a) -> lnRules ln (Algebraic.expand a)
+        | Function (Log, a) -> lnRules log (Algebraic.expand a)
+        | FunctionN (Log, [basis;a]) -> lognRules basis (Algebraic.expand a)
         | a -> a
 
     [<CompiledName("Contract")>]

--- a/src/Symbolics/Expression.fs
+++ b/src/Symbolics/Expression.fs
@@ -360,10 +360,10 @@ module Operators =
     let ln = function
         | One -> zero
         | x -> Function (Ln, x)
-    let log = function
+    let log10 = function
         | One -> zero
         | x -> Function (Log, x)
-    let logn basis x = FunctionN (Log, [basis; x])
+    let log basis x = FunctionN (Log, [basis; x])
 
     let sin = function
         | Zero -> zero
@@ -397,7 +397,7 @@ module Operators =
         | Abs -> abs x
         | Exp -> exp x
         | Ln -> ln x
-        | Log -> log x
+        | Log -> log10 x
         | Sin -> sin x
         | Cos -> cos x
         | Tan -> tan x
@@ -453,8 +453,8 @@ type Expression with
 
     static member Exp (x) = Operators.exp x
     static member Ln (x) = Operators.ln x
-    static member Log(x) = Operators.log x
-    static member Log (basis, x) = Operators.logn basis x
+    static member Log(x) = Operators.log10 x
+    static member Log (basis, x) = Operators.log basis x
 
     static member Sin (x) = Operators.sin x
     static member Cos (x) = Operators.cos x

--- a/src/Symbolics/Expression.fs
+++ b/src/Symbolics/Expression.fs
@@ -360,7 +360,10 @@ module Operators =
     let ln = function
         | One -> zero
         | x -> Function (Ln, x)
-    let log basis x = divide (ln x) (ln basis)
+    let log = function
+        | One -> zero
+        | x -> Function (Log, x)
+    let logn basis x = FunctionN (Log, [basis; x])
 
     let sin = function
         | Zero -> zero
@@ -387,12 +390,14 @@ module Operators =
     let arcsin x = Function (Asin, x)
     let arccos x = Function (Acos, x)
     let arctan x = Function (Atan, x)
+    let arctan2 x y = FunctionN (Atan, [x;y])
 
     let apply f x =
         match f with
         | Abs -> abs x
         | Exp -> exp x
         | Ln -> ln x
+        | Log -> log x
         | Sin -> sin x
         | Cos -> cos x
         | Tan -> tan x
@@ -406,7 +411,11 @@ module Operators =
         | Sec -> sec x
         | Csc -> csc x
 
-    let applyN (f: Function) (xs: Expression list) = failwith "not supported yet"
+    let applyN (f: Function) (xs: Expression list) =
+        match f, xs with
+        | Atan, [x;y] -> arctan2 x y
+        | Log, [b; x] -> logn b x
+        | _ -> failwith "not supported"
 
 
 type Expression with
@@ -444,7 +453,8 @@ type Expression with
 
     static member Exp (x) = Operators.exp x
     static member Ln (x) = Operators.ln x
-    static member Log (basis, x) = Operators.log basis x
+    static member Log(x) = Operators.log x
+    static member Log (basis, x) = Operators.logn basis x
 
     static member Sin (x) = Operators.sin x
     static member Cos (x) = Operators.cos x

--- a/src/Symbolics/Expression.fs
+++ b/src/Symbolics/Expression.fs
@@ -414,7 +414,7 @@ module Operators =
     let applyN (f: Function) (xs: Expression list) =
         match f, xs with
         | Atan, [x;y] -> arctan2 x y
-        | Log, [b; x] -> logn b x
+        | Log, [b; x] -> log b x
         | _ -> failwith "not supported"
 
 

--- a/src/Symbolics/Symbols.fs
+++ b/src/Symbolics/Symbols.fs
@@ -4,7 +4,7 @@ type Symbol = Symbol of string
 
 type Function =
     | Abs
-    | Ln | Exp
+    | Ln | Log | Exp
     | Sin | Cos | Tan
     | Cot | Sec | Csc 
     | Cosh | Sinh | Tanh

--- a/src/SymbolicsUnitTests/Tests.fs
+++ b/src/SymbolicsUnitTests/Tests.fs
@@ -224,8 +224,8 @@ let ``Expressions are always in auto-simplified form`` () =
 
     x + ln x ==> "x + ln(x)"
     x + ln (x+1) ==> "x + ln(1 + x)"
-    x + log (x+1) ==> "x + log(1 + x)"
-    x + (logn x (x+1)) ==> "x + log(x,1 + x)"
+    x + log10 (x+1) ==> "x + log(1 + x)"
+    x + (log x (x+1)) ==> "x + log(x,1 + x)"
     2*abs x ==> "2*|x|"
     x + abs (-x) ==> "x + |x|"
     abs (-3Q) ==> "3"
@@ -448,19 +448,19 @@ let ``Algebaric Operators`` () =
     negate (x + y**2) ==> "-(x + y^2)"
 
     Algebraic.factors (b*cos(x)*ln(d)*x) ==+> ["b"; "x"; "ln(d)"; "cos(x)"]
-    Algebraic.factors (b*cos(x)*log(d)*x) ==+> ["b"; "x"; "log(d)"; "cos(x)"]
-    Algebraic.factors (b*cos(x)*(logn d (d*2))*x) ==+> ["b"; "x"; "log(d,2*d)"; "cos(x)"]
+    Algebraic.factors (b*cos(x)*log10(d)*x) ==+> ["b"; "x"; "log(d)"; "cos(x)"]
+    Algebraic.factors (b*cos(x)*(log d (d*2))*x) ==+> ["b"; "x"; "log(d,2*d)"; "cos(x)"]
     Algebraic.factors (b+cos(x)) ==+> ["b + cos(x)"]
     Algebraic.summands (b+cos(x)+ln(d)+x) ==+> ["b"; "x"; "ln(d)"; "cos(x)"]
-    Algebraic.summands (b+cos(x)+log(d)+x) ==+> ["b"; "x"; "log(d)"; "cos(x)"]
-    Algebraic.summands (b+cos(x)+(logn d (d*2))+x) ==+> ["b"; "x"; "log(d,2*d)"; "cos(x)"]
+    Algebraic.summands (b+cos(x)+log10(d)+x) ==+> ["b"; "x"; "log(d)"; "cos(x)"]
+    Algebraic.summands (b+cos(x)+(log d (d*2))+x) ==+> ["b"; "x"; "log(d,2*d)"; "cos(x)"]
     Algebraic.summands (b*cos(x)) ==+> ["b*cos(x)"]
 
     Algebraic.factorsInteger (2Q/3*b*cos(x)) --> (2I, [1Q/3; b; cos(x)])
 
     Algebraic.separateFactors x (b*cos(x)*ln(d)*x) ==|> ("b*ln(d)", "x*cos(x)")
-    Algebraic.separateFactors x (b*cos(x)*log(d)*x) ==|> ("b*log(d)", "x*cos(x)")
-    Algebraic.separateFactors x (b*cos(x)*(logn d (d*2))*x) ==|> ("b*log(d,2*d)", "x*cos(x)")
+    Algebraic.separateFactors x (b*cos(x)*log10(d)*x) ==|> ("b*log(d)", "x*cos(x)")
+    Algebraic.separateFactors x (b*cos(x)*(log d (d*2))*x) ==|> ("b*log(d,2*d)", "x*cos(x)")
     Algebraic.separateFactors x (c*x*sin(x)/2) ==|> ("(1/2)*c", "x*sin(x)")
 
     Algebraic.expand ((x+1)*(x+3)) ==> "3 + 4*x + x^2"
@@ -488,8 +488,8 @@ let ``Algebaric Operators`` () =
     Exponential.expand (1/(exp(2*x) - (exp(x))**2)) ==> "⧝"
     Exponential.expand (exp((x+y)*(x-y))) ==> "exp(x^2)/exp(y^2)"
     Exponential.expand (ln((c*x)**a) + ln(y**b*z)) ==> "a*ln(c) + a*ln(x) + b*ln(y) + ln(z)"
-    Exponential.expand (log((c*x)**a) + log(y**b*z)) ==> "a*log(c) + a*log(x) + b*log(y) + log(z)"
-    Exponential.expand ((logn 5Q ((c*x)**a)) + (logn 3Q (y**b*z))) ==> "a*log(5,c) + a*log(5,x) + b*log(3,y) + log(3,z)"
+    Exponential.expand (log10((c*x)**a) + log10(y**b*z)) ==> "a*log(c) + a*log(x) + b*log(y) + log(z)"
+    Exponential.expand ((log 5Q ((c*x)**a)) + (log 3Q (y**b*z))) ==> "a*log(5,c) + a*log(5,x) + b*log(3,y) + log(3,z)"
 
     Exponential.contract (exp(x)*exp(y)) ==> "exp(x + y)"
     Exponential.contract (exp(x)**a) ==> "exp(a*x)"
@@ -532,10 +532,10 @@ let ``Differentiation and Taylor Series`` () =
     Calculus.differentiate x ((ln x) / (ln 10Q)) ==> "1/(x*ln(10))"
     Calculus.differentiate x (ln x) ==> "1/x"
     Calculus.differentiate x (ln (x**2)) ==> "2/x"
-    Calculus.differentiate x (log x) ==> "1/(x*ln(10))"
-    Calculus.differentiate x (log (x**2)) ==> "2/(x*ln(10))"
-    Calculus.differentiate x (logn 10Q x) ==> "1/(x*ln(10))"
-    Calculus.differentiate x (logn x (x**2)) ==> "2/(x*ln(x)) - ln(x^2)/(x*ln(x)^2)"
+    Calculus.differentiate x (log10 x) ==> "1/(x*ln(10))"
+    Calculus.differentiate x (log10 (x**2)) ==> "2/(x*ln(10))"
+    Calculus.differentiate x (log 10Q x) ==> "1/(x*ln(10))"
+    Calculus.differentiate x (log x (x**2)) ==> "2/(x*ln(x)) - ln(x^2)/(x*ln(x)^2)"
 
     Calculus.taylor 3 x 0Q (1/(1-x)) ==> "1 + x + x^2"
     Calculus.taylor 3 x 1Q (1/x) ==> "3 - 3*x + x^2"
@@ -691,8 +691,8 @@ let ``General Polynomial Expressions`` () =
 
     Polynomial.isMonomial x (a * x**2) --> true
     Polynomial.isMonomial x (ln(a) * x**2) --> true
-    Polynomial.isMonomial x (log(a) * x**2) --> true
-    Polynomial.isMonomial x ((logn a (a**2)) * x**2) --> true
+    Polynomial.isMonomial x (log10(a) * x**2) --> true
+    Polynomial.isMonomial x ((log a (a**2)) * x**2) --> true
     Polynomial.isMonomial x (x**2 + a) --> false
     Polynomial.isPolynomial x (x**2 + x**3) --> true
     Polynomial.isPolynomial x (x**2 + 2*x) --> true
@@ -700,8 +700,8 @@ let ``General Polynomial Expressions`` () =
 
     Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (a * x**2 * y**2) --> true
     Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (ln(a) * x**2 * y**2) --> true
-    Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (log(a) * x**2 * y**2) --> true
-    Polynomial.isMonomialMV (Polynomial.symbols [x;y]) ((logn a (a**2)) * x**2 * y**2) --> true
+    Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (log10(a) * x**2 * y**2) --> true
+    Polynomial.isMonomialMV (Polynomial.symbols [x;y]) ((log a (a**2)) * x**2 * y**2) --> true
     Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (x**2 + y**2) --> false
     Polynomial.isPolynomialMV (Polynomial.symbols [x;y]) (x**2 + y**2) --> true
     Polynomial.isPolynomialMV (Polynomial.symbols [x+1]) ((x+1)**2 + 2*(x+1)) --> true
@@ -749,14 +749,14 @@ let ``General Polynomial Expressions`` () =
     Polynomial.collectTerms x (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "x*(4*a + 5*b + 2*a*y + 3*b*y)"
     Polynomial.collectTerms a (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "5*b*x + 3*b*x*y + a*(4*x + 2*x*y)"
     Polynomial.collectTerms (ln(a)) (2*x*ln(a)*y + 4*x*ln(a) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*ln(a)"
-    Polynomial.collectTerms (log(a)) (2*x*log(a)*y + 4*x*log(a) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*log(a)"
-    Polynomial.collectTerms (logn a (a**2)) (2*x*(logn a (a**2))*y + 4*x*(logn a (a**2)) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*log(a,a^2)"
+    Polynomial.collectTerms (log10(a)) (2*x*log10(a)*y + 4*x*log10(a) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*log(a)"
+    Polynomial.collectTerms (log a (a**2)) (2*x*(log a (a**2))*y + 4*x*(log a (a**2)) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*log(a,a^2)"
 
     Polynomial.collectTermsMV (Polynomial.symbols [x;y]) (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "(4*a + 5*b)*x + (2*a + 3*b)*x*y"
     Polynomial.collectTermsMV (Polynomial.symbols [a;b]) (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "a*(4*x + 2*x*y) + b*(5*x + 3*x*y)"
     Polynomial.collectTermsMV (Polynomial.symbols [x;ln(a)]) (2*x*ln(a)*y + 4*x*ln(a) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*ln(a)"
-    Polynomial.collectTermsMV (Polynomial.symbols [x;log(a)]) (2*x*log(a)*y + 4*x*log(a) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*log(a)"
-    Polynomial.collectTermsMV (Polynomial.symbols [x;(logn a (a**2))]) (2*x*(logn a (a**2))*y + 4*x*(logn a (a**2)) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*log(a,a^2)"
+    Polynomial.collectTermsMV (Polynomial.symbols [x;log10(a)]) (2*x*log10(a)*y + 4*x*log10(a) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*log(a)"
+    Polynomial.collectTermsMV (Polynomial.symbols [x;(log a (a**2))]) (2*x*(log a (a**2))*y + 4*x*(log a (a**2)) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*log(a,a^2)"
 
     Polynomial.isSquareFree x (x**3 + 1) --> true
     Polynomial.isSquareFree x (x**2 - 2) --> true

--- a/src/SymbolicsUnitTests/Tests.fs
+++ b/src/SymbolicsUnitTests/Tests.fs
@@ -224,6 +224,8 @@ let ``Expressions are always in auto-simplified form`` () =
 
     x + ln x ==> "x + ln(x)"
     x + ln (x+1) ==> "x + ln(1 + x)"
+    x + log (x+1) ==> "x + log(1 + x)"
+    x + (logn x (x+1)) ==> "x + log(x,1 + x)"
     2*abs x ==> "2*|x|"
     x + abs (-x) ==> "x + |x|"
     abs (-3Q) ==> "3"
@@ -257,6 +259,9 @@ let ``Parse infix expressions`` () =
     Infix.parseOrUndefined "sin x-1" ==> "Undefined"
     Infix.parseOrUndefined "sin -x" ==> "sin - x"
     Infix.parseOrUndefined "sin" ==> "sin"
+    Infix.parseOrUndefined "atan(x,y)" ==> "atan(x,y)"
+    Infix.parseOrUndefined "atan ( x , y )"  ==> "atan(x,y)"
+    Infix.parseOrUndefined " atan ( - x, - y ) " ==> "atan(-x,-y)"
 
     Infix.parseOrThrow "1/(a*b)" ==> "1/(a*b)"
     Infix.parseOrThrow "exp(a)^exp(b)" ==> "exp(a)^exp(b)"
@@ -443,13 +448,19 @@ let ``Algebaric Operators`` () =
     negate (x + y**2) ==> "-(x + y^2)"
 
     Algebraic.factors (b*cos(x)*ln(d)*x) ==+> ["b"; "x"; "ln(d)"; "cos(x)"]
+    Algebraic.factors (b*cos(x)*log(d)*x) ==+> ["b"; "x"; "log(d)"; "cos(x)"]
+    Algebraic.factors (b*cos(x)*(logn d (d*2))*x) ==+> ["b"; "x"; "log(d,2*d)"; "cos(x)"]
     Algebraic.factors (b+cos(x)) ==+> ["b + cos(x)"]
     Algebraic.summands (b+cos(x)+ln(d)+x) ==+> ["b"; "x"; "ln(d)"; "cos(x)"]
+    Algebraic.summands (b+cos(x)+log(d)+x) ==+> ["b"; "x"; "log(d)"; "cos(x)"]
+    Algebraic.summands (b+cos(x)+(logn d (d*2))+x) ==+> ["b"; "x"; "log(d,2*d)"; "cos(x)"]
     Algebraic.summands (b*cos(x)) ==+> ["b*cos(x)"]
 
     Algebraic.factorsInteger (2Q/3*b*cos(x)) --> (2I, [1Q/3; b; cos(x)])
 
     Algebraic.separateFactors x (b*cos(x)*ln(d)*x) ==|> ("b*ln(d)", "x*cos(x)")
+    Algebraic.separateFactors x (b*cos(x)*log(d)*x) ==|> ("b*log(d)", "x*cos(x)")
+    Algebraic.separateFactors x (b*cos(x)*(logn d (d*2))*x) ==|> ("b*log(d,2*d)", "x*cos(x)")
     Algebraic.separateFactors x (c*x*sin(x)/2) ==|> ("(1/2)*c", "x*sin(x)")
 
     Algebraic.expand ((x+1)*(x+3)) ==> "3 + 4*x + x^2"
@@ -477,6 +488,8 @@ let ``Algebaric Operators`` () =
     Exponential.expand (1/(exp(2*x) - (exp(x))**2)) ==> "⧝"
     Exponential.expand (exp((x+y)*(x-y))) ==> "exp(x^2)/exp(y^2)"
     Exponential.expand (ln((c*x)**a) + ln(y**b*z)) ==> "a*ln(c) + a*ln(x) + b*ln(y) + ln(z)"
+    Exponential.expand (log((c*x)**a) + log(y**b*z)) ==> "a*log(c) + a*log(x) + b*log(y) + log(z)"
+    Exponential.expand ((logn 5Q ((c*x)**a)) + (logn 3Q (y**b*z))) ==> "a*log(5,c) + a*log(5,x) + b*log(3,y) + log(3,z)"
 
     Exponential.contract (exp(x)*exp(y)) ==> "exp(x + y)"
     Exponential.contract (exp(x)**a) ==> "exp(a*x)"
@@ -515,6 +528,14 @@ let ``Differentiation and Taylor Series`` () =
     Calculus.differentiate x (a*x**2) ==> "2*a*x"
     Calculus.differentiate x (a*x**b) ==> "a*b*x^(-1 + b)"
     Calculus.differentiate x (a*x**2 + b*x + c) ==> "b + 2*a*x"
+    Calculus.differentiate x (1Q/x) ==> "-1/x^2"
+    Calculus.differentiate x ((ln x) / (ln 10Q)) ==> "1/(x*ln(10))"
+    Calculus.differentiate x (ln x) ==> "1/x"
+    Calculus.differentiate x (ln (x**2)) ==> "2/x"
+    Calculus.differentiate x (log x) ==> "1/(x*ln(10))"
+    Calculus.differentiate x (log (x**2)) ==> "2/(x*ln(10))"
+    Calculus.differentiate x (logn 10Q x) ==> "1/(x*ln(10))"
+    Calculus.differentiate x (logn x (x**2)) ==> "2/(x*ln(x)) - ln(x^2)/(x*ln(x)^2)"
 
     Calculus.taylor 3 x 0Q (1/(1-x)) ==> "1 + x + x^2"
     Calculus.taylor 3 x 1Q (1/x) ==> "3 - 3*x + x^2"
@@ -670,6 +691,8 @@ let ``General Polynomial Expressions`` () =
 
     Polynomial.isMonomial x (a * x**2) --> true
     Polynomial.isMonomial x (ln(a) * x**2) --> true
+    Polynomial.isMonomial x (log(a) * x**2) --> true
+    Polynomial.isMonomial x ((logn a (a**2)) * x**2) --> true
     Polynomial.isMonomial x (x**2 + a) --> false
     Polynomial.isPolynomial x (x**2 + x**3) --> true
     Polynomial.isPolynomial x (x**2 + 2*x) --> true
@@ -677,6 +700,8 @@ let ``General Polynomial Expressions`` () =
 
     Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (a * x**2 * y**2) --> true
     Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (ln(a) * x**2 * y**2) --> true
+    Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (log(a) * x**2 * y**2) --> true
+    Polynomial.isMonomialMV (Polynomial.symbols [x;y]) ((logn a (a**2)) * x**2 * y**2) --> true
     Polynomial.isMonomialMV (Polynomial.symbols [x;y]) (x**2 + y**2) --> false
     Polynomial.isPolynomialMV (Polynomial.symbols [x;y]) (x**2 + y**2) --> true
     Polynomial.isPolynomialMV (Polynomial.symbols [x+1]) ((x+1)**2 + 2*(x+1)) --> true
@@ -724,10 +749,14 @@ let ``General Polynomial Expressions`` () =
     Polynomial.collectTerms x (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "x*(4*a + 5*b + 2*a*y + 3*b*y)"
     Polynomial.collectTerms a (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "5*b*x + 3*b*x*y + a*(4*x + 2*x*y)"
     Polynomial.collectTerms (ln(a)) (2*x*ln(a)*y + 4*x*ln(a) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*ln(a)"
+    Polynomial.collectTerms (log(a)) (2*x*log(a)*y + 4*x*log(a) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*log(a)"
+    Polynomial.collectTerms (logn a (a**2)) (2*x*(logn a (a**2))*y + 4*x*(logn a (a**2)) + 3*x*y*b + 5*x*b + c) ==> "c + 5*b*x + 3*b*x*y + (4*x + 2*x*y)*log(a,a^2)"
 
     Polynomial.collectTermsMV (Polynomial.symbols [x;y]) (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "(4*a + 5*b)*x + (2*a + 3*b)*x*y"
     Polynomial.collectTermsMV (Polynomial.symbols [a;b]) (2*x*a*y + 4*a*x + 3*x*y*b + 5*x*b) ==> "a*(4*x + 2*x*y) + b*(5*x + 3*x*y)"
     Polynomial.collectTermsMV (Polynomial.symbols [x;ln(a)]) (2*x*ln(a)*y + 4*x*ln(a) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*ln(a)"
+    Polynomial.collectTermsMV (Polynomial.symbols [x;log(a)]) (2*x*log(a)*y + 4*x*log(a) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*log(a)"
+    Polynomial.collectTermsMV (Polynomial.symbols [x;(logn a (a**2))]) (2*x*(logn a (a**2))*y + 4*x*(logn a (a**2)) + 3*x*y*b + 5*x*b + c) ==> "c + x*(5*b + 3*b*y) + x*(4 + 2*y)*log(a,a^2)"
 
     Polynomial.isSquareFree x (x**3 + 1) --> true
     Polynomial.isSquareFree x (x**2 - 2) --> true


### PR DESCRIPTION
Adds the support for two-argument functions Atan and Log, also adds support for single-argument Log function, that is equivalent to Log10

`atan(x,y)` acts as an alternative syntax to `atan(x/y)`, `log(x)` is algebrically equivalent to `ln(x)/ln(10)`, `log(b,x)` is algebrically equivalent to `ln(x)/ln(b)`.

### Rationale
While all three of these functions could be translated into equivalent expressions using identities, the usage of such alternative syntaxes can lead to different results when evaluating the expressions due to fewer floating point operations, because the .NET Framework provides special methods for such cases.