### PR TITLE
Add Bessel functions

### DIFF
--- a/src/Symbolics/Approximation.fs
+++ b/src/Symbolics/Approximation.fs
@@ -147,6 +147,43 @@ module Approximation =
         | Real a -> Real (Trig.Acoth a)
         | Complex a -> Complex (Trig.Acoth a)
 
+    let besselj nu z =
+        match nu, z with
+        | Real a, Real b -> failwith "not supported"        // Real (Bessel.BesselJ (a, b))
+        | Real a, Complex b -> failwith "not supported"     // Complex (Bessel.BesselJ (a, b))
+        | Complex a, Real b -> failwith "not supported"     // Complex (Bessel.BesselJ (a, b))
+        | Complex a, Complex b -> failwith "not supported"  // Complex (Bessel.BesselJ (a, b))        
+    let bessely nu z =
+        match nu, z with
+        | Real a, Real b -> failwith "not supported"        // Real (Bessel.BesselY (a, b))
+        | Real a, Complex b -> failwith "not supported"     // Complex (Bessel.BesselY (a, b))
+        | Complex a, Real b -> failwith "not supported"     // Complex (Bessel.BesselY (a, b))
+        | Complex a, Complex b -> failwith "not supported"  // Complex (Bessel.BesselY (a, b))
+    let besseli nu z =
+        match nu, z with
+        | Real a, Real b -> failwith "not supported"        // Real (Bessel.BesselI (a, b))
+        | Real a, Complex b -> failwith "not supported"     // Complex (Bessel.BesselI (a, b))
+        | Complex a, Real b -> failwith "not supported"     // Complex (Bessel.BesselI (a, b))
+        | Complex a, Complex b -> failwith "not supported"  // Complex (Bessel.BesselI (a, b))
+    let besselk nu z =
+        match nu, z with
+        | Real a, Real b -> failwith "not supported"        // Real (Bessel.BesselK (a, b))
+        | Real a, Complex b -> failwith "not supported"     // Complex (Bessel.BesselK (a, b))
+        | Complex a, Real b -> failwith "not supported"     // Complex (Bessel.BesselK (a, b))
+        | Complex a, Complex b -> failwith "not supported"  // Complex (Bessel.BesselK (a, b))
+    let hankelh1 nu z =
+        match nu, z with
+        | Real a, Real b -> failwith "not supported"        // Real (Bessel.HankelH1 (a, b))
+        | Real a, Complex b -> failwith "not supported"     // Complex (Bessel.HankelH1 (a, b))
+        | Complex a, Real b -> failwith "not supported"     // Complex (Bessel.HankelH1 (a, b))
+        | Complex a, Complex b -> failwith "not supported"  // Complex (Bessel.HankelH1 (a, b))
+    let hankelh2 nu z =
+        match nu, z with
+        | Real a, Real b -> failwith "not supported"        // Real (Bessel.HankelH2 (a, b))
+        | Real a, Complex b -> failwith "not supported"     // Complex (Bessel.HankelH2 (a, b))
+        | Complex a, Real b -> failwith "not supported"     // Complex (Bessel.HankelH2 (a, b))
+        | Complex a, Complex b -> failwith "not supported"  // Complex (Bessel.HankelH2 (a, b))
+
     let apply f a =
         match f with
         | Abs -> abs a
@@ -182,6 +219,12 @@ module Approximation =
         match f, xs with
         | Atan, [x; y] -> atan2 x y
         | Log, [b; x] -> log b x
+        | BesselJ, [nu; x] -> besselj nu x
+        | BesselY, [nu; x] -> bessely nu x
+        | BesselI, [nu; x] -> besseli nu x
+        | BesselK, [nu; x] -> besselk nu x        
+        | HankelH1, [nu; x] -> hankelh1 nu x
+        | HankelH2, [nu; x] -> hankelh2 nu x
         | _ -> failwith "not supported"
 
     let isZero = function

--- a/src/Symbolics/Calculus.fs
+++ b/src/Symbolics/Calculus.fs
@@ -26,10 +26,10 @@ module Calculus =
         | Function (Log, x) -> (differentiate symbol ((ln x) / (ln 10Q)))
         | Function (Sin, x) -> (differentiate symbol x) * cos(x)
         | Function (Cos, x) -> -(differentiate symbol x) * sin(x)
-        | Function (Tan, x) -> 2*(differentiate symbol x) / (cos(2*x)+1)
-        | Function (Cosh, x) -> (differentiate symbol x) * sinh (x)
-        | Function (Sinh, x) -> (differentiate symbol x) * cosh (x)
-        | Function (Tanh, x) -> 2*(differentiate symbol x) / (cosh(2*x)+1)
+        | Function (Tan, x) -> 2*(differentiate symbol x) / (cos(2Q * x) + 1Q)
+        | Function (Cosh, x) -> (differentiate symbol x) * sinh(x)
+        | Function (Sinh, x) -> (differentiate symbol x) * cosh(x)
+        | Function (Tanh, x) -> 2*(differentiate symbol x) / (cosh(2Q * x) + 1)
         | Function (Asin, x) -> (1Q / sqrt(1Q - pow x 2Q)) * (differentiate symbol x)
         | Function (Acos, x) -> (-1Q / sqrt(1Q - pow x 2Q)) * (differentiate symbol x)
         | Function (Atan, x) -> (1Q / (1Q + pow x 2Q)) * (differentiate symbol x)
@@ -41,7 +41,7 @@ module Calculus =
         | Function (Acot, x) -> -(differentiate symbol x) / (1Q + pow x 2Q)
         | Function (Csch, x) -> (differentiate symbol x) * (-coth(x) * csch(x))
         | Function (Sech, x) -> (differentiate symbol x) * (-tanh(x) * sech(x))
-        | Function (Coth, x) -> -2 * (differentiate symbol x) / (cosh(2 * x) - 1)
+        | Function (Coth, x) -> -2 * (differentiate symbol x) / (cosh(2Q * x) - 1Q)
         | Function (Asinh, x) -> (differentiate symbol x) / (sqrt(pow x 2Q + 1Q))
         | Function (Acosh, x) -> (differentiate symbol x) / (sqrt(x - 1Q) * sqrt(x + 1Q))
         | Function (Atanh, x) -> (differentiate symbol x) / (1Q - pow x 2Q)
@@ -51,6 +51,12 @@ module Calculus =
         | Function (Abs, _) -> failwith "not supported"
         | FunctionN (Atan, [x; y]) -> differentiate symbol (tan (x / y))
         | FunctionN (Log, [b; x]) -> differentiate symbol ((ln x) / (ln b))
+        | FunctionN (BesselJ, [nu; x]) -> (differentiate symbol x) * ((besselj (nu - 1Q) x) - (besselj (nu + 1Q) x)) / 2Q
+        | FunctionN (BesselY, [nu; x]) -> (differentiate symbol x) * ((bessely (nu - 1Q) x) - (bessely (nu + 1Q) x)) / 2Q
+        | FunctionN (BesselI, [nu; x]) -> (differentiate symbol x) * ((besseli (nu - 1Q) x) + (besseli (nu + 1Q) x)) / 2Q
+        | FunctionN (BesselK, [nu; x]) -> (differentiate symbol x) * (-(besselk (nu - 1Q) x) - (besselk (nu + 1Q) x)) / 2Q
+        | FunctionN (HankelH1, [nu; x]) -> (differentiate symbol x) * ((hankelh1 (nu - 1Q) x) - (hankelh1 (nu + 1Q) x)) / 2Q
+        | FunctionN (HankelH2, [nu; x]) -> (differentiate symbol x) * ((hankelh2 (nu - 1Q) x) - (hankelh2 (nu + 1Q) x)) / 2Q
         | FunctionN (_) -> failwith "not supported"
         | Product [] -> failwith "invalid expression"
 

--- a/src/Symbolics/Evaluate.fs
+++ b/src/Symbolics/Evaluate.fs
@@ -202,6 +202,18 @@ module Evaluate =
         | Log, [Real b; Complex x] -> Complex (Complex.Log(x, b))
         | Log, [Complex b; Complex x] -> Complex(Complex.Log(x) / Complex.Log(b))
         | Log, [Complex b; Real x] -> Complex(Complex.Log(Complex.Create(x, 0.0)) / Complex.Log(b))
+        | BesselJ, [Real nu; Real x] -> failwith "not supported"        // Real (Bessel.BesselJ(nu, x))
+        | BesselJ, [Real nu; Complex x] -> failwith "not supported"     // Complex (Bessel.BesselJ(nu, x))
+        | BesselY, [Real nu; Real x] -> failwith "not supported"        // Real (Bessel.BesselY(nu, x))
+        | BesselY, [Real nu; Complex x] -> failwith "not supported"     // Complex (Bessel.BesselY(nu, x))
+        | BesselI, [Real nu; Real x] -> failwith "not supported"        // Real (Bessel.BesselI(nu, x))
+        | BesselI, [Real nu; Complex x] -> failwith "not supported"     // Complex (Bessel.BesselI(nu, x))
+        | BesselK, [Real nu; Real x] -> failwith "not supported"        // Real (Bessel.BesselK(nu, x))
+        | BesselK, [Real nu; Complex x] -> failwith "not supported"     // Complex (Bessel.BesselK(nu, x))
+        | HankelH1, [Real nu; Real x] -> failwith "not supported"       // Real (Bessel.HankelH1(nu, x))
+        | HankelH1, [Real nu; Complex x] -> failwith "not supported"    // Complex (Bessel.HankelH1(nu, x))
+        | HankelH2, [Real nu; Real x] -> failwith "not supported"       // Real (Bessel.HankelH2(nu, x))
+        | HankelH2, [Real nu; Complex x] -> failwith "not supported"    // Complex (Bessel.HankelH2(nu, x))
         | _ -> failwith "not supported"
 
     [<CompiledName("Evaluate")>]

--- a/src/Symbolics/Expression.fs
+++ b/src/Symbolics/Expression.fs
@@ -711,6 +711,63 @@ module Operators =
         | Product ((Number n)::ax) when n.IsNegative -> Function (Acoth, multiply (Number -n) (Product ax)) |> negate
         | x -> Function (Acoth, x)
 
+    let rec besselj nu x = 
+        match nu, x with
+        | Undefined, _ -> undefined
+        | _, Undefined -> undefined
+        | Zero, Zero -> one // J(0, 0) = 1
+        | Positive, Zero -> zero // J(n, 0) = 0 for n > 0
+        | Number n, _  when n.IsNegative -> (pow minusOne (Number -n)) |> multiply (besselj (Number -n) x) // J(-n, x) = pow(-1, n) * J(n, x)
+        | Product ((Number n)::ax), _ when n.IsNegative -> (pow minusOne (multiply (Number -n) (Product ax))) |> multiply (besselj (multiply (Number -n) (Product ax)) x)
+        | _, PositiveInfinity -> zero // J(nu, oo) = 0
+        | _, NegativeInfinity -> zero // J(nu, -oo) = 0
+        | _, _ -> FunctionN (BesselJ, [nu; x])
+    let rec bessely nu x = 
+        match nu, x with
+        | Undefined, _ -> undefined
+        | _, Undefined -> undefined
+        | Zero, Zero -> negativeInfinity // Y(0, 0) = -oo
+        | Positive, Zero -> complexInfinity // Y(n, 0) = ⧝ for n > 0
+        | Number n, _  when n.IsNegative -> (pow minusOne (Number -n)) |> multiply (bessely (Number -n) x) // Y(-n, x) = pow(-1, n) * Y(n, x)
+        | Product ((Number n)::ax), _ when n.IsNegative -> (pow minusOne (multiply (Number -n) (Product ax))) |> multiply (bessely (multiply (Number -n) (Product ax)) x)
+        | _, PositiveInfinity -> zero // Y(nu, oo) = 0
+        | _, NegativeInfinity -> zero // Y(nu, -oo) = 0
+        | _, _ -> FunctionN (BesselY, [nu; x])
+    let rec besseli nu x = 
+        match nu, x with
+        | Undefined, _ -> undefined
+        | _, Undefined -> undefined
+        | Zero, Zero -> one // I(0, 0) = 1
+        | Positive, Zero -> zero // I(n, 0) = 0 for n > 0
+        | Number n, _  when n.IsNegative -> besseli (Number -n) x // I(-n, x) = I(n, x)
+        | Product ((Number n)::ax), _ when n.IsNegative -> besseli (multiply (Number -n) (Product ax)) x
+        | _, _ -> FunctionN (BesselI, [nu; x])    
+    let rec besselk nu x = 
+        match nu, x with
+        | Undefined, _ -> undefined
+        | _, Undefined -> undefined
+        | Zero, Zero -> infinity // K(0, 0) = oo
+        | Positive, Zero -> complexInfinity // K(n, 0) = ⧝ for n > 0
+        | Number n, _  when n.IsNegative -> besselk (Number -n) x // K(-n, x) = K(n, x)
+        | Product ((Number n)::ax), _ when n.IsNegative -> besselk (multiply (Number -n) (Product ax)) x
+        | _, _ -> FunctionN (BesselK, [nu; x])
+    let rec hankelh1 nu x = 
+        match nu, x with
+        | Undefined, _ -> undefined
+        | _, Undefined -> undefined
+        | _, Zero -> complexInfinity // H1(n, 0) = ⧝
+        | Number n, _  when n.IsNegative -> (pow minusOne (Number -n)) |> multiply (hankelh1 (Number -n) x) // H1(-n, x) = pow(-1, n) * H1(n, x)
+        | Product ((Number n)::ax), _ when n.IsNegative -> (pow minusOne (multiply (Number -n) (Product ax))) |> multiply (hankelh1 (multiply (Number -n) (Product ax)) x)
+        | _, _ -> FunctionN (HankelH1, [nu; x])
+    let rec hankelh2 nu x = 
+        match nu, x with
+        | Undefined, _ -> undefined
+        | _, Undefined -> undefined
+        | _, Zero -> complexInfinity // H2(n, 0) = ⧝
+        | Number n, _  when n.IsNegative -> (pow minusOne (Number -n)) |> multiply (hankelh2 (Number -n) x) // H2(-n, x) = pow(-1, n) * H2(n, x)
+        | Product ((Number n)::ax), _ when n.IsNegative -> (pow minusOne (multiply (Number -n) (Product ax))) |> multiply (hankelh2 (multiply (Number -n) (Product ax)) x)
+        | _, _ -> FunctionN (HankelH2, [nu; x])
+
     let apply f x =
         match f with
         | Abs -> abs x
@@ -747,6 +804,12 @@ module Operators =
         match f, xs with
         | Atan, [x;y] -> arctan2 x y
         | Log, [b; x] -> log b x
+        | BesselJ, [nu; x] -> besselj nu x
+        | BesselY, [nu; x] -> bessely nu x
+        | BesselI, [nu; x] -> besseli nu x
+        | BesselK, [nu; x] -> besselk nu x
+        | HankelH1, [nu; x] -> hankelh1 nu x
+        | HankelH2, [nu; x] -> hankelh2 nu x
         | _ -> failwith "not supported"
 
 
@@ -815,6 +878,13 @@ type Expression with
     static member ArcCsch (x) = Operators.arccsch x
     static member ArcSech (x) = Operators.arcsech x
     static member ArcCoth (x) = Operators.arccoth x
+
+    static member BesselJ (n, x) = Operators.besselj n x // Bessel Function of the First Kind
+    static member BesselY (n, x) = Operators.bessely n x // Bessel Function of the Second Kind
+    static member BesselI (n, x) = Operators.besseli n x // Modified Bessel Function of the First Kind    
+    static member BesselK (n, x) = Operators.besselk n x // Modified Bessel Function of the Second Kind
+    static member HankelH1 (n, x) = Operators.hankelh1 n x // Hankel Function of the First Kind
+    static member HankelH2 (n, x) = Operators.hankelh2 n x // Hankel Function of the Second Kind
 
     static member Apply (f, x) = Operators.apply f x
     static member ApplyN (f, xs) = Operators.applyN f xs

--- a/src/Symbolics/SymbolicExpression.fs
+++ b/src/Symbolics/SymbolicExpression.fs
@@ -235,6 +235,13 @@ type SymbolicExpression(expression:Expression) =
     member this.ArcSech() = SymbolicExpression(Expression.ArcSech(expression))
     member this.ArcCoth() = SymbolicExpression(Expression.ArcCoth(expression))
 
+    member this.BesselJ(n:SymbolicExpression) = SymbolicExpression(Expression.BesselJ(n.Expression, expression))
+    member this.BesselY(n:SymbolicExpression) = SymbolicExpression(Expression.BesselY(n.Expression, expression))
+    member this.BesselI(n:SymbolicExpression) = SymbolicExpression(Expression.BesselI(n.Expression, expression))
+    member this.BesselK(n:SymbolicExpression) = SymbolicExpression(Expression.BesselK(n.Expression, expression))
+    member this.HankelH1(n:SymbolicExpression) = SymbolicExpression(Expression.HankelH1(n.Expression, expression))
+    member this.HankelH2(n:SymbolicExpression) = SymbolicExpression(Expression.HankelH2(n.Expression, expression))
+
 
     // STRUCTURE
     member this.NumberOfOperands = expression |> Structure.numberOfOperands

--- a/src/Symbolics/Symbolics.fsproj
+++ b/src/Symbolics/Symbolics.fsproj
@@ -1,152 +1,152 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{a8667c7d-cc10-4519-acfe-1b4d3c190e97}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>MathNet.Symbolics</RootNamespace>
-    <AssemblyName>MathNet.Symbolics</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
-    <Name>MathNet.Symbolics</Name>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\out\lib\Net40\</OutputPath>
-    <IntermediateOutputPath>..\..\obj\lib\Net40\</IntermediateOutputPath>
-    <BaseIntermediateOutputPath>..\..\obj\lib\Net40\</BaseIntermediateOutputPath>
-    <DocumentationFile>..\..\out\lib\Net40\MathNet.Symbolics.xml</DocumentationFile>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <Tailcalls>true</Tailcalls>
-    <DefineConstants>TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\out\lib-debug\Net40\</OutputPath>
-    <IntermediateOutputPath>..\..\obj\lib-debug\Net40\</IntermediateOutputPath>
-    <BaseIntermediateOutputPath>..\..\obj\lib-debug\Net40\</BaseIntermediateOutputPath>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <Tailcalls>false</Tailcalls>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Symbols.fs" />
-    <Compile Include="Approximation.fs" />
-    <Compile Include="Value.fs" />
-    <Compile Include="Expression.fs" />
-    <Compile Include="Numbers.fs" />
-    <Compile Include="Structure.fs" />
-    <Compile Include="Algebraic.fs" />
-    <Compile Include="Calculus.fs" />
-    <Compile Include="Polynomial.fs" />
-    <Compile Include="Rational.fs" />
-    <Compile Include="Exponential.fs" />
-    <Compile Include="Trigonometric.fs" />
-    <Compile Include="Approximate.fs" />
-    <Compile Include="Visual\VisualExpression.fs" />
-    <Compile Include="Visual\Infix.fs" />
-    <Compile Include="Visual\LaTeX.fs" />
-    <Compile Include="Visual\MathML.fs" />
-    <Compile Include="Typed\Quotations.fs" />
-    <Compile Include="Typed\Linq.fs" />
-    <Compile Include="Compile.fs" />
-    <Compile Include="Evaluate.fs" />
-    <Compile Include="SymbolicExpression.fs" />
-    <None Include="MathNet.Symbolics.fsx" />
-    <None Include="Script.fsx" />
-    <None Include="app.config" />
-    <Content Include="paket.references" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.6.1')">
-      <ItemGroup>
-        <Reference Include="FParsec">
-          <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="FParsecCS">
-          <HintPath>..\..\packages\FParsec\lib\net40-client\FParsecCS.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
-      <ItemGroup>
-        <Reference Include="FSharp.Core">
-          <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.1'">
-      <ItemGroup>
-        <Reference Include="FSharp.Core">
-          <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.6.1')">
-      <ItemGroup>
-        <Reference Include="System.Numerics">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="MathNet.Numerics">
-          <HintPath>..\..\packages\MathNet.Numerics\lib\net40\MathNet.Numerics.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.6.1')">
-      <ItemGroup>
-        <Reference Include="MathNet.Numerics.FSharp">
-          <HintPath>..\..\packages\MathNet.Numerics.FSharp\lib\net40\MathNet.Numerics.FSharp.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <SchemaVersion>2.0</SchemaVersion>
+        <ProjectGuid>{a8667c7d-cc10-4519-acfe-1b4d3c190e97}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <RootNamespace>MathNet.Symbolics</RootNamespace>
+        <AssemblyName>MathNet.Symbolics</AssemblyName>
+        <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+        <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+        <Name>MathNet.Symbolics</Name>
+        <TargetFrameworkProfile />
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <OutputPath>..\..\out\lib\Net40\</OutputPath>
+        <IntermediateOutputPath>..\..\obj\lib\Net40\</IntermediateOutputPath>
+        <BaseIntermediateOutputPath>..\..\obj\lib\Net40\</BaseIntermediateOutputPath>
+        <DocumentationFile>..\..\out\lib\Net40\MathNet.Symbolics.xml</DocumentationFile>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <Tailcalls>true</Tailcalls>
+        <DefineConstants>TRACE</DefineConstants>
+        <WarningLevel>3</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <OutputPath>..\..\out\lib-debug\Net40\</OutputPath>
+        <IntermediateOutputPath>..\..\obj\lib-debug\Net40\</IntermediateOutputPath>
+        <BaseIntermediateOutputPath>..\..\obj\lib-debug\Net40\</BaseIntermediateOutputPath>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <Tailcalls>false</Tailcalls>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <WarningLevel>3</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup>
+        <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+    </PropertyGroup>
+    <Choose>
+        <When Condition="'$(VisualStudioVersion)' == '11.0'">
+            <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+                <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+                <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+            </PropertyGroup>
+        </Otherwise>
+    </Choose>
+    <Import Project="$(FSharpTargetsPath)" />
+    <ItemGroup>
+        <Compile Include="AssemblyInfo.fs" />
+        <Compile Include="Symbols.fs" />
+        <Compile Include="Approximation.fs" />
+        <Compile Include="Value.fs" />
+        <Compile Include="Expression.fs" />
+        <Compile Include="Numbers.fs" />
+        <Compile Include="Structure.fs" />
+        <Compile Include="Algebraic.fs" />
+        <Compile Include="Calculus.fs" />
+        <Compile Include="Polynomial.fs" />
+        <Compile Include="Rational.fs" />
+        <Compile Include="Exponential.fs" />
+        <Compile Include="Trigonometric.fs" />
+        <Compile Include="Approximate.fs" />
+        <Compile Include="Visual\VisualExpression.fs" />
+        <Compile Include="Visual\Infix.fs" />
+        <Compile Include="Visual\LaTeX.fs" />
+        <Compile Include="Visual\MathML.fs" />
+        <Compile Include="Typed\Quotations.fs" />
+        <Compile Include="Typed\Linq.fs" />
+        <Compile Include="Compile.fs" />
+        <Compile Include="Evaluate.fs" />
+        <Compile Include="SymbolicExpression.fs" />
+        <None Include="MathNet.Symbolics.fsx" />
+        <None Include="Script.fsx" />
+        <None Include="app.config" />
+        <Content Include="paket.references" />
+    </ItemGroup>
+    <ItemGroup>
+        <Reference Include="mscorlib" />
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Xml" />
+        <Reference Include="System.Xml.Linq" />
+    </ItemGroup>
+    <Choose>
+        <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+            <ItemGroup>
+                <Reference Include="FParsec">
+                    <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>
+                    <Private>True</Private>
+                    <Paket>True</Paket>
+                </Reference>
+                <Reference Include="FParsecCS">
+                    <HintPath>..\..\packages\FParsec\lib\net40-client\FParsecCS.dll</HintPath>
+                    <Private>True</Private>
+                    <Paket>True</Paket>
+                </Reference>
+            </ItemGroup>
+        </When>
+    </Choose>
+    <Choose>
+        <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+            <ItemGroup>
+                <Reference Include="FSharp.Core">
+                    <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
+                    <Private>True</Private>
+                    <Paket>True</Paket>
+                </Reference>
+            </ItemGroup>
+        </When>
+        <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.1'">
+            <ItemGroup>
+                <Reference Include="FSharp.Core">
+                    <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
+                    <Private>True</Private>
+                    <Paket>True</Paket>
+                </Reference>
+            </ItemGroup>
+        </When>
+    </Choose>
+    <Choose>
+        <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+            <ItemGroup>
+                <Reference Include="System.Numerics">
+                    <Paket>True</Paket>
+                </Reference>
+                <Reference Include="MathNet.Numerics">
+                    <HintPath>..\..\packages\MathNet.Numerics\lib\net40\MathNet.Numerics.dll</HintPath>
+                    <Private>True</Private>
+                    <Paket>True</Paket>
+                </Reference>
+            </ItemGroup>
+        </When>
+    </Choose>
+    <Choose>
+        <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+            <ItemGroup>
+                <Reference Include="MathNet.Numerics.FSharp">
+                    <HintPath>..\..\packages\MathNet.Numerics.FSharp\lib\net40\MathNet.Numerics.FSharp.dll</HintPath>
+                    <Private>True</Private>
+                    <Paket>True</Paket>
+                </Reference>
+            </ItemGroup>
+        </When>
+    </Choose>
 </Project>

--- a/src/Symbolics/Symbols.fs
+++ b/src/Symbolics/Symbols.fs
@@ -1,5 +1,7 @@
 ﻿namespace MathNet.Symbolics
 
+open MathNet.Numerics
+
 type Symbol = Symbol of string
 
 type Function =
@@ -13,6 +15,12 @@ type Function =
     | Acsc | Asec | Acot
     | Asinh | Acosh | Atanh
     | Acsch | Asech | Acoth
+    | BesselJ   // Bessel function of the first kind
+    | BesselY   // Bessel function of the second kind
+    | BesselI   // Modified Bessel function of the first kind
+    | BesselK   // Modified Bessel function of the second kind
+    | HankelH1  // Hankel function of the first kind
+    | HankelH2  // Hankel function of the second kind
 
 type Constant =
     | E

--- a/src/Symbolics/Visual/Infix.fs
+++ b/src/Symbolics/Visual/Infix.fs
@@ -202,6 +202,12 @@ module private InfixFormatter =
         | Acsc -> "acsc" | Asec -> "asec" | Acot -> "acot"
         | Acosh -> "acosh" | Asinh -> "asinh" | Atanh -> "atanh"
         | Asech -> "asech" | Acsch -> "acsch" | Acoth -> "acoth"
+        | BesselJ -> "besselj"
+        | BesselI -> "besseli"
+        | BesselY -> "bessely"
+        | BesselK -> "besselk"
+        | HankelH1 -> "hankelh1"
+        | HankelH2 -> "hankelh2"
 
     // priority: 1=additive 2=product 3=power
 

--- a/src/Symbolics/Visual/LaTeX.fs
+++ b/src/Symbolics/Visual/LaTeX.fs
@@ -27,6 +27,12 @@ module private LaTeXFormatter =
     let latexFunctionNName = function
         | "log" -> "\\log"
         | "atan" -> "\\operatorname{atan2}"
+        | "besselj" -> "\\besselj"
+        | "bessely" -> "\\bessely"
+        | "besseli" -> "\\besseli"
+        | "besselk" -> "\\besselk"
+        | "hankelh1" -> "\\hankelh1"
+        | "hankelh2" -> "\\hankelh2"
         | x -> sprintf "\\operatorname{%s}" x
 
     let private dropParenthesis = function
@@ -126,6 +132,78 @@ module private LaTeXFormatter =
         | VisualExpression.FunctionN ("log", [basis; x]) ->
             write "\\log_{"
             format write basis
+            match x with
+            | VisualExpression.Sum _ ->
+                write "}\\left("
+                format write x
+                write "\\right)"
+            | _ ->
+                write "}{"
+                format write x
+                write "}"
+        | VisualExpression.FunctionN ("besselj", [nu; x]) ->
+            write "\\J_{"
+            format write nu
+            match x with
+            | VisualExpression.Sum _ ->
+                write "}\\left("
+                format write x
+                write "\\right)"
+            | _ ->
+                write "}{"
+                format write x
+                write "}"
+        | VisualExpression.FunctionN ("bessely", [nu; x]) ->
+            write "\\Y_{"
+            format write nu
+            match x with
+            | VisualExpression.Sum _ ->
+                write "}\\left("
+                format write x
+                write "\\right)"
+            | _ ->
+                write "}{"
+                format write x
+                write "}"
+        | VisualExpression.FunctionN ("besseli", [nu; x]) ->
+            write "\\I_{"
+            format write nu
+            match x with
+            | VisualExpression.Sum _ ->
+                write "}\\left("
+                format write x
+                write "\\right)"
+            | _ ->
+                write "}{"
+                format write x
+                write "}"        
+        | VisualExpression.FunctionN ("besselk", [nu; x]) ->
+            write "\\K_{"
+            format write nu
+            match x with
+            | VisualExpression.Sum _ ->
+                write "}\\left("
+                format write x
+                write "\\right)"
+            | _ ->
+                write "}{"
+                format write x
+                write "}"
+        | VisualExpression.FunctionN ("hankelh1", [nu; x]) ->
+            write "\\H^{(1)}_{"
+            format write nu
+            match x with
+            | VisualExpression.Sum _ ->
+                write "}\\left("
+                format write x
+                write "\\right)"
+            | _ ->
+                write "}{"
+                format write x
+                write "}"
+        | VisualExpression.FunctionN ("hankelh2", [nu; x]) ->
+            write "\\H^{(2)}_{"
+            format write nu
             match x with
             | VisualExpression.Sum _ ->
                 write "}\\left("

--- a/src/Symbolics/Visual/VisualExpression.fs
+++ b/src/Symbolics/Visual/VisualExpression.fs
@@ -202,6 +202,12 @@ type DefaultVisualStyle() =
         | Acsc -> "acsc" | Asec -> "asec" | Acot -> "acot"
         | Acosh -> "acosh" | Asinh -> "asinh" | Atanh -> "atanh"
         | Acsch -> "acsch" | Asech -> "asech" | Acoth -> "acoth"
+        | BesselJ -> "besselj"
+        | BesselY -> "bessely"
+        | BesselI -> "besseli"
+        | BesselK -> "besselk"
+        | HankelH1 -> "hankelh1"
+        | HankelH2 -> "hankelh2"
 
     member private this.FromExpression e = VisualExpression.fromExpression this e
 

--- a/src/SymbolicsUnitTests/Global.fs
+++ b/src/SymbolicsUnitTests/Global.fs
@@ -37,3 +37,5 @@ let c = symbol "c"
 let d = symbol "d"
 let e = symbol "e"
 let f = symbol "f"
+
+let n = symbol "n"

--- a/src/SymbolicsUnitTests/Operators/Bessel.fs
+++ b/src/SymbolicsUnitTests/Operators/Bessel.fs
@@ -1,0 +1,133 @@
+﻿module Bessel
+
+open Expecto
+open MathNet.Symbolics
+open Operators
+
+let tests =
+    testList "Bessel" [
+        testList "BesselJ" [
+            test "Special Values" {
+                besselj 0Q 0Q ==> "1"
+                besselj 1Q 0Q ==> "0"
+                besselj -1Q 0Q ==> "0"
+                besselj n PositiveInfinity ==> "0"
+                besselj n NegativeInfinity ==> "0"
+            }
+
+            test "Connection Formulas" {
+                besselj -n x ==> "(-1)^(n)*besselj(n,x)"
+            }
+
+            test "Calculus" {
+                Calculus.differentiate x (besselj n (sqrt x)) ==> "(besselj(-1 + n,sqrt(x)) - besselj(1 + n,sqrt(x)))/(4*sqrt(x))"
+            }
+
+            test "Latex Format" {
+                LaTeX.format (besselj n x) --> "\J_{n}{x}"
+            }
+        ]
+
+        testList "BesselY" [
+            test "Special Values" {
+                bessely 0Q 0Q ==> "-∞"
+                bessely 1Q 0Q ==> "⧝"
+                bessely -1Q 0Q ==> "⧝"
+                bessely n PositiveInfinity ==> "0"
+                bessely n NegativeInfinity ==> "0"
+            }
+
+            test "Connection Formulas" {
+                bessely -n x ==> "(-1)^(n)*bessely(n,x)"
+            }
+
+            test "Calculus" {
+                Calculus.differentiate x (bessely n (sqrt x)) ==> "(bessely(-1 + n,sqrt(x)) - bessely(1 + n,sqrt(x)))/(4*sqrt(x))"
+            }
+
+            test "Latex Format" {
+                LaTeX.format (bessely n x) --> "\Y_{n}{x}"
+            }
+        ]
+
+        testList "BesselI" [
+            test "Special Values" {
+                besseli 0Q 0Q ==> "1"
+                besseli 1Q 0Q ==> "0"
+                besseli -1Q 0Q ==> "0"
+            }
+
+            test "Connection Formulas" {
+                besseli -n x ==> "besseli(n,x)"
+            }
+
+            test "Calculus" {
+                Calculus.differentiate x (besseli n (sqrt x)) ==> "(besseli(-1 + n,sqrt(x)) + besseli(1 + n,sqrt(x)))/(4*sqrt(x))"
+            }
+
+            test "Latex Format" {
+                LaTeX.format (besseli n x) --> "\I_{n}{x}"
+            }
+        ]
+
+        testList "BesselK" [
+            test "Special Values" {
+                besselk 0Q 0Q ==> "∞"
+                besselk 1Q 0Q ==> "⧝"
+                besselk -1Q 0Q ==> "⧝"
+            }
+
+            test "Connection Formulas" {
+                besselk -n x ==> "besselk(n,x)"
+            }
+
+            test "Calculus" {
+                Calculus.differentiate x (besselk n (sqrt x)) ==> "(-besselk(-1 + n,sqrt(x)) - besselk(1 + n,sqrt(x)))/(4*sqrt(x))"
+            }
+
+            test "Latex Format" {
+                LaTeX.format (besselk n x) --> "\K_{n}{x}"
+            }
+        ]
+
+        testList "HankelH1" [
+            test "Special Values" {
+                hankelh1 0Q 0Q ==> "⧝"
+                hankelh1 1Q 0Q ==> "⧝"
+                hankelh1 -1Q 0Q ==> "⧝"
+            }
+
+            test "Connection Formulas" {
+                hankelh1 -n x ==> "(-1)^(n)*hankelh1(n,x)"
+            }
+
+            test "Calculus" {
+                Calculus.differentiate x (hankelh1 n (sqrt x)) ==> "(hankelh1(-1 + n,sqrt(x)) - hankelh1(1 + n,sqrt(x)))/(4*sqrt(x))"
+            }
+
+            test "Latex Format" {
+                LaTeX.format (hankelh1 n x) --> "\H^{(1)}_{n}{x}"
+            }
+        ]
+
+        testList "HankelH2" [
+            test "Special Values" {
+                hankelh2 0Q 0Q ==> "⧝"
+                hankelh2 1Q 0Q ==> "⧝"
+                hankelh2 -1Q 0Q ==> "⧝"
+            }
+
+            test "Connection Formulas" {
+                hankelh2 -n x ==> "(-1)^(n)*hankelh2(n,x)"
+            }
+
+            test "Calculus" {
+                Calculus.differentiate x (hankelh2 n (sqrt x)) ==> "(hankelh2(-1 + n,sqrt(x)) - hankelh2(1 + n,sqrt(x)))/(4*sqrt(x))"
+            }
+
+            test "Latex Format" {
+                LaTeX.format (hankelh2 n x) --> "\H^{(2)}_{n}{x}"
+            }
+        ]
+    ]
+

--- a/src/SymbolicsUnitTests/Operators/Operators.fs
+++ b/src/SymbolicsUnitTests/Operators/Operators.fs
@@ -10,5 +10,5 @@ let tests =
         Arithmetic.tests
         Exponential.tests
         Trigonometry.tests
-
+        Bessel.tests
     ]

--- a/src/SymbolicsUnitTests/SymbolicsUnitTests.fsproj
+++ b/src/SymbolicsUnitTests/SymbolicsUnitTests.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="Operators\Arithmetic.fs" />
     <Compile Include="Operators\Exponential.fs" />
     <Compile Include="Operators\Trigonometry.fs" />
+    <Compile Include="Operators\Bessel.fs" />
     <Compile Include="Operators\Operators.fs" />
     <Compile Include="Polynomial\Polynomial.fs" />
     <Compile Include="Visual\Infix.fs" />


### PR DESCRIPTION
Bessel functions are added. The real order n and complex argument z are assumed, but numerical evaluations must wait until the MathNet Numerics supports them.

- `BesselJ(n, z)` Bessel Function of the First Kind
- `BesselY(n, z)` Bessel Function of the Second Kind
- `BesselI(n, z)` Modified Bessel Function of the First Kind
- `BesselK(n, z)` Modified Bessel Function of the Second Kind
- `HankelH1(n, z)` Hankel Function of the First Kind
- `HankelH2(n, z)` Hankel Function of the Second Kind

Currently, the Numerics provides only `I(0, x)`, `I(1, x)`, `K(0, x)`, and `K(1, x)` for the real argument x.