### PR TITLE
Adds the functions min, max, sum, avg and mean

### DIFF
--- a/src/Symbolics/Evaluate.fs
+++ b/src/Symbolics/Evaluate.fs
@@ -226,10 +226,10 @@ module Evaluate =
         | HankelH1, [Real nu; Complex x] -> Complex (SpecialFunctions.HankelH1 (nu, x))
         | HankelH2, [Real nu; Real x] -> Complex (SpecialFunctions.HankelH2 (nu, complex x 0.0))
         | HankelH2, [Real nu; Complex x] -> Complex (SpecialFunctions.HankelH2 (nu, x))
-        | Min, vs -> vs |> List.map (fun (Real c) -> c) |> List.min |> Real
-        | Max, vs -> vs |> List.map (fun (Real c) -> c) |> List.max |> Real
-        | Avg, vs -> vs |> List.map (fun (Real c) -> c) |> List.average |> Real
-        | Function.Sum, vs -> vs |> List.map (fun (Real c) -> c) |> List.sum |> Real
+        | Min, vs -> vs |> List.minBy (fun (Real c) -> c)
+        | Max, vs -> vs |> List.maxBy (fun (Real c) -> c)
+        | Avg, vs -> vs |> List.averageBy (fun (Real c) -> c) |> Real
+        | Function.Sum, vs -> vs |> List.sumBy (fun (Real c) -> c) |> Real
         | Median, vs ->
             let rec median (list : float list) = 
                 match list with
@@ -247,8 +247,7 @@ module Evaluate =
                     let len = c |> List.length
                     c 
                     |> List.sort
-                    |> List.skip (len / 2)
-                    |> List.head
+                    |> List.item (len / 2)
                 | _ -> failwith "impossible!"
 
             vs |> List.map (fun (Real c) -> c) |> median |> Real

--- a/src/Symbolics/Evaluate.fs
+++ b/src/Symbolics/Evaluate.fs
@@ -226,6 +226,32 @@ module Evaluate =
         | HankelH1, [Real nu; Complex x] -> Complex (SpecialFunctions.HankelH1 (nu, x))
         | HankelH2, [Real nu; Real x] -> Complex (SpecialFunctions.HankelH2 (nu, complex x 0.0))
         | HankelH2, [Real nu; Complex x] -> Complex (SpecialFunctions.HankelH2 (nu, x))
+        | Min, vs -> vs |> List.map (fun (Real c) -> c) |> List.min |> Real
+        | Max, vs -> vs |> List.map (fun (Real c) -> c) |> List.max |> Real
+        | Avg, vs -> vs |> List.map (fun (Real c) -> c) |> List.average |> Real
+        | Function.Sum, vs -> vs |> List.map (fun (Real c) -> c) |> List.sum |> Real
+        | Median, vs ->
+            let rec median (list : float list) = 
+                match list with
+                | [] -> invalidArg "list" "List must not be empty!"
+                | [c] -> c 
+                | [a; b] -> (a + b) / 2.
+                | c when (c |> List.length) % 2 = 0 ->
+                    let len = c |> List.length
+                    c 
+                    |> List.sort
+                    |> List.skip (len / 2 - 1)
+                    |> List.take 2
+                    |> median
+                | c when (c |> List.length) % 2 = 1 ->
+                    let len = c |> List.length
+                    c 
+                    |> List.sort
+                    |> List.skip (len / 2)
+                    |> List.head
+                | _ -> failwith "impossible!"
+
+            vs |> List.map (fun (Real c) -> c) |> median |> Real
         | _ -> failwith "not supported"
 
     [<CompiledName("Evaluate")>]

--- a/src/Symbolics/Expression.fs
+++ b/src/Symbolics/Expression.fs
@@ -388,6 +388,12 @@ module Operators =
     let root n x = pow x (pow n minusOne)
     let sqrt x = root two x
 
+    let min'  vs = FunctionN (Min,  vs)
+    let max'  vs = FunctionN (Max,  vs)
+    let avg'  vs = FunctionN (Avg,  vs)
+    let mean' vs = FunctionN (Median, vs)
+    let sum'  vs = FunctionN (Function.Sum,  vs)
+
     let abs = function
         | Undefined -> undefined
         | oo when isInfinity oo -> infinity
@@ -862,6 +868,11 @@ module Operators =
         | BesselKRatio, [nu; x] -> besselkratio nu x
         | HankelH1, [nu; x] -> hankelh1 nu x
         | HankelH2, [nu; x] -> hankelh2 nu x
+        | Min,  vs -> min'  vs
+        | Max,  vs -> max'  vs
+        | Avg,  vs -> avg'  vs
+        | Median, vs -> mean' vs
+        | Function.Sum,  vs -> sum'  vs
         | _ -> failwith "not supported"
 
 

--- a/src/Symbolics/Expression.fs
+++ b/src/Symbolics/Expression.fs
@@ -960,6 +960,11 @@ type Expression with
     static member HankelH1 (n, x) = Operators.hankelh1 n x // Hankel Function of the First Kind
     static member HankelH2 (n, x) = Operators.hankelh2 n x // Hankel Function of the Second Kind
 
+    static member Min (xs) = Operators.min' xs
+    static member Max (xs) = Operators.max' xs
+    static member Avg (xs) = Operators.avg' xs
+    static member Median (xs) = Operators.mean' xs
+
     static member Apply (f, x) = Operators.apply f x
     static member ApplyN (f, xs) = Operators.applyN f xs
 

--- a/src/Symbolics/SymbolicExpression.fs
+++ b/src/Symbolics/SymbolicExpression.fs
@@ -255,6 +255,11 @@ type SymbolicExpression(expression:Expression) =
     member this.HankelH1(n:SymbolicExpression) = SymbolicExpression(Expression.HankelH1(n.Expression, expression))
     member this.HankelH2(n:SymbolicExpression) = SymbolicExpression(Expression.HankelH2(n.Expression, expression))
 
+    member this.Min(ns:SymbolicExpression list) = SymbolicExpression(Expression.Min(ns |> List.map (fun n -> n.Expression)))
+    member this.Max(ns:SymbolicExpression list) = SymbolicExpression(Expression.Max(ns |> List.map (fun n -> n.Expression)))
+    member this.Avg(ns:SymbolicExpression list) = SymbolicExpression(Expression.Avg(ns |> List.map (fun n -> n.Expression)))
+    member this.Median(ns:SymbolicExpression list) = SymbolicExpression(Expression.Median(ns |> List.map (fun n -> n.Expression)))
+
 
     // STRUCTURE
     member this.NumberOfOperands = expression |> Structure.numberOfOperands

--- a/src/Symbolics/Symbols.fs
+++ b/src/Symbolics/Symbols.fs
@@ -27,6 +27,8 @@ type Function =
                        // BesselKRatio(n, x) is defined as BesselKRatio(n + 1, x) / BesselKRatio(n, x).
     | HankelH1  // Hankel function of the first kind
     | HankelH2  // Hankel function of the second kind
+    | Min | Max | Avg | Median
+    | Sum
 
 type Constant =
     | E

--- a/src/Symbolics/Visual/Infix.fs
+++ b/src/Symbolics/Visual/Infix.fs
@@ -211,6 +211,11 @@ module private InfixFormatter =
         | BesselKRatio -> "besselkratio"
         | HankelH1 -> "hankelh1"
         | HankelH2 -> "hankelh2"
+        | Min -> "min"
+        | Max -> "max"
+        | Function.Sum -> "sum"
+        | Avg -> "avg"
+        | Median -> "median"
 
     // priority: 1=additive 2=product 3=power
 

--- a/src/Symbolics/Visual/VisualExpression.fs
+++ b/src/Symbolics/Visual/VisualExpression.fs
@@ -213,6 +213,11 @@ type DefaultVisualStyle() =
         | BesselKRatio -> "besselkratio"
         | HankelH1 -> "hankelh1"
         | HankelH2 -> "hankelh2"
+        | Min -> "min"
+        | Max -> "max"
+        | Function.Sum -> "sum"
+        | Avg -> "avg"
+        | Median -> "median"
 
     member private this.FromExpression e = VisualExpression.fromExpression this e
 


### PR DESCRIPTION
I needed more functions for a Project using Math.NET. These are min, max, avg, mean and sum. With this PR I hope go get this into the official package and get some guidance on how to properly integrate this into Math.NET. The issues I am seeing right now:
1. `sum` is not a really pretty function. It was requested so I have it here for the time beeing. But I am happy to remove it again
2. The implementation for `median` just sits there in the match block that is otherwise tidy. I am missing a good spot to place it (and make sure it is correct ;) )
3. Function names in general. Maybe othernames, or `average` instead of `avg` should be preferred?
4. General formatting stuff.

I'd be happy to increment on this PR if there is interest in having those functions in Math.NET

Todos

- [ ] Missing simplifications (`min(1,2) ⇒ 1`)
- [ ] Missing tests
- [x] Missing implementation for applyN of Approximation.fs
- [x] Missing member for SymbolicExpression.fs
- [ ] Missing implementation for toLambda of Linq.fs
- [x] Missing implementation for functionName of Infix.fs
- [x] Missing implementation for functionName of VisualExpression.fs