### PR TITLE
Added customized function (a little ugly)

### DIFF
--- a/src/Symbolics/Definition.fs
+++ b/src/Symbolics/Definition.fs
@@ -1,0 +1,12 @@
+﻿namespace MathNet.Symbolics
+
+module Definition =
+
+    let funDict = new System.Collections.Concurrent.ConcurrentDictionary<string, (Symbol list) * Expression>()
+
+    let define fnm exp =
+        funDict.AddOrUpdate(
+            fnm
+            , (fun nm -> exp)
+            , (fun nm cur_exp -> exp)
+        )

--- a/src/Symbolics/Symbolics.fsproj
+++ b/src/Symbolics/Symbolics.fsproj
@@ -24,6 +24,7 @@ Minor internal simplifications and streamlining</PackageReleaseNotes>
     <Compile Include="Approximation.fs" />
     <Compile Include="Value.fs" />
     <Compile Include="Expression.fs" />
+    <Compile Include="Definition.fs" />
     <Compile Include="Numbers.fs" />
     <Compile Include="Structure.fs" />
     <Compile Include="Algebraic.fs" />


### PR DESCRIPTION
For supporting code like the following:

```
#r @"src\Symbolics\bin\Debug\netstandard2.0\MathNet.Symbolics.dll"
#r @"nuget:MathNet.Numerics"
#r @"nuget:FsUnit"
#r @"nuget:FParsec"
#r @"nuget:MathNet.Numerics.FSharp"
#load @"src\Symbolics.Tests\Global.fs"

open MathNet.Numerics
open MathNet.Symbolics
open Global
open Operators
open VariableSets.Alphabet
type Expr = SymbolicExpression

let symV = Symbol "v"
let symW = Symbol "w"
let symX = Symbol "x"
let symY = Symbol "y"
let symZ = Symbol "z"


open Definition
define "test" ([symV; symW], (v + w)*2)
SymbolicExpression(Infix.parseOrThrow("2^test(x, 2 * x)")).Evaluate(dict[ "x", FloatingPoint.Real 2.0; ])
```

Result:
```
InfixParser.parse: 2^test(x, 2 * x)
val it : FloatingPoint = Real 4096.0
```

Code:
```
SymbolicExpression(cFun("test", [x + (fromInt32 10); (fromDouble 100.0)])*2).Evaluate(dict[ "x", FloatingPoint.Real 9.0; ])

```

Result:
```
val it : FloatingPoint = Real 476.0
```