### PR TITLE
Fix build.cmd occuring a log file format error

### DIFF
--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -28,6 +28,6 @@
     <PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />
     <PackageReference Include="Fake.IO.Zip" Version="6.0.0" />
     <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.100" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.356" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When running `build.cmd`, the following error occurs:
````
Unsupported log file format. Latest supported version is 17, the log file has version 21.
````

This can be resolved by updating the `MSBuild.StructuredLogger` version in `build.fsproj` from 2.2.100 to 2.2.356. I happened to discover that the latest version works without issues.